### PR TITLE
change readr::read_csv calls in R scripts to safely handle missing csv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.DS_Store
 *.venv
 /flu_ar2/output/
+/flu_flusion/output/
+/flu_flusion/intermediate-output/

--- a/covid_ar6_pooled/1_plot.R
+++ b/covid_ar6_pooled/1_plot.R
@@ -27,9 +27,15 @@ selected_model <- "UMass-ar6_pooled"
 forecasts <- forecasts |>
   dplyr::filter(model_id == selected_model)
 
-target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+raw_target_data <- try(
+  readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")),
+  silent = TRUE)
+if (inherits(raw_target_data, "try-error")) {
+  stop(paste0('error reading csv file: ', conditionMessage(attr(raw_target_data, "condition"))))
+}
+
+target_data <- raw_target_data |>
   dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total COVID-19 Admissions"))
-colnames(target_data) <- c("date", "abbreviation", "value")
 target_data <- target_data |>
   dplyr::mutate(
     abbreviation = ifelse(abbreviation == "USA", "US", abbreviation)

--- a/covid_ar6_pooled/main.py
+++ b/covid_ar6_pooled/main.py
@@ -1,7 +1,10 @@
-import click
 import datetime
+
+import click
 from dateutil import relativedelta
-import subprocess
+
+from util.utils import run_script
+
 
 @click.command()
 @click.option(
@@ -28,9 +31,9 @@ def main(today_date: str | None = None, short_run: bool = False):
     else:
         short_run_flag = []
     
-    subprocess.run(["python", "0_ar6_pooled.py",
-                    "--reference_date", str(reference_date)] + short_run_flag)
-    subprocess.run(["Rscript", "1_plot.R", str(reference_date)])
+    for script_args in [["python", "0_ar6_pooled.py", "--reference_date", str(reference_date)] + short_run_flag,
+                        ["Rscript", "1_plot.R", str(reference_date)]]:
+        run_script(script_args)
 
 
 if __name__ == "__main__":

--- a/covid_gbqr/1_plot.R
+++ b/covid_gbqr/1_plot.R
@@ -24,8 +24,14 @@ forecasts <- hub_con |>
   dplyr::collect() |>
   dplyr::left_join(locations)
 
-# target_data <- readr::read_csv("https://raw.githubusercontent.com/CDCgov/covid19-forecast-hub/refs/heads/main/target-data/covid-hospital-admissions.csv") |>
-target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+raw_target_data <- try(
+  readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")),
+  silent = TRUE)
+if (inherits(raw_target_data, "try-error")) {
+  stop(paste0('error reading csv file: ', conditionMessage(attr(raw_target_data, "condition"))))
+}
+
+target_data <- raw_target_data |>
   dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total COVID-19 Admissions"))
 colnames(target_data) <- c("date", "abbreviation", "value")
 target_data <- target_data |>

--- a/covid_gbqr/main.py
+++ b/covid_gbqr/main.py
@@ -1,7 +1,10 @@
-import click
 import datetime
+
+import click
 from dateutil import relativedelta
-import subprocess
+
+from util.utils import run_script
+
 
 @click.command()
 @click.option(
@@ -28,9 +31,9 @@ def main(today_date: str | None = None, short_run: bool = False):
     else:
         short_run_flag = []
     
-    subprocess.run(["python", "0_gbqr.py",
-                    "--reference_date", str(reference_date)] + short_run_flag)
-    subprocess.run(["Rscript", "1_plot.R", str(reference_date)])
+    for script_args in [["python", "0_gbqr.py", "--reference_date", str(reference_date)] + short_run_flag,
+                        ["Rscript", "1_plot.R", str(reference_date)]]:
+        run_script(script_args)
 
 
 if __name__ == "__main__":

--- a/flu_ar2/main.py
+++ b/flu_ar2/main.py
@@ -1,11 +1,13 @@
-import click
 import datetime
-from dateutil import relativedelta
 from pathlib import Path
-import subprocess
 from types import SimpleNamespace
 
+import click
+from dateutil import relativedelta
 from idmodels.sarix import SARIXModel
+
+from util.utils import run_script
+
 
 @click.command()
 @click.option(
@@ -21,11 +23,11 @@ def main(today_date: str | None = None):
     except (TypeError, ValueError):  # if today_date is None or a bad format
         today_date = datetime.date.today()
     reference_date = today_date + relativedelta.relativedelta(weekday=5)
-    
+
     model_config = SimpleNamespace(
         model_class = "sarix",
         model_name = "AR2",
-        
+
         # data sources and adjustments for reporting issues
         sources = ["nhsn"],
 
@@ -45,11 +47,11 @@ def main(today_date: str | None = None):
         # sharing of information about parameters
         theta_pooling="none",
         sigma_pooling="none",
-        
+
         # covariates
         x = []
     )
-    
+
     run_config = SimpleNamespace(
         disease="flu",
         ref_date=reference_date,
@@ -73,11 +75,11 @@ def main(today_date: str | None = None):
         num_samples = 2000,
         num_chains = 1
     )
-    
+
     model = SARIXModel(model_config)
     model.run(run_config)
-    
-    subprocess.run(["Rscript", "plot.R", str(reference_date)])
+
+    run_script(["Rscript", "plot.R", str(reference_date)])
 
 
 if __name__ == "__main__":

--- a/flu_ar2/plot.R
+++ b/flu_ar2/plot.R
@@ -24,7 +24,14 @@ forecasts <- dplyr::bind_rows(
 ) |>
   dplyr::left_join(locations)
 
-target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+raw_target_data <- try(
+  readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")),
+  silent = TRUE)
+if (inherits(raw_target_data, "try-error")) {
+  stop(paste0('error reading csv file: ', conditionMessage(attr(raw_target_data, "condition"))))
+}
+
+target_data <- raw_target_data |>
   dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total Influenza Admissions"))
 colnames(target_data) <- c("date", "abbreviation", "value")
 target_data <- target_data |>

--- a/flu_flusion/3_plot.R
+++ b/flu_flusion/3_plot.R
@@ -30,7 +30,14 @@ flusion <- hub_con |>
 forecasts <- dplyr::bind_rows(components |> dplyr::mutate(output_type_id = as.character(output_type_id)), flusion) |>
   dplyr::left_join(locations)
 
-target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+raw_target_data <- try(
+  readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")),
+  silent = TRUE)
+if (inherits(raw_target_data, "try-error")) {
+  stop(paste0('error reading csv file: ', conditionMessage(attr(raw_target_data, "condition"))))
+}
+
+target_data <- raw_target_data |>
   dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total Influenza Admissions"))
 colnames(target_data) <- c("date", "abbreviation", "value")
 target_data <- target_data |>

--- a/flu_flusion/main.py
+++ b/flu_flusion/main.py
@@ -1,7 +1,10 @@
-import click
 import datetime
+
+import click
 from dateutil import relativedelta
-import subprocess
+
+from util.utils import run_script
+
 
 @click.command()
 @click.option(
@@ -22,18 +25,17 @@ def main(today_date: str | None = None, short_run: bool = False):
     except (TypeError, ValueError):  # if today_date is None or a bad format
         today_date = datetime.date.today()
     reference_date = today_date + relativedelta.relativedelta(weekday=5)
-    
+
     if short_run:
         short_run_flag = ["--short_run"]
     else:
         short_run_flag = []
-    
-    subprocess.run(["python", "0_ar6_pooled.py",
-                    "--reference_date", str(reference_date)] + short_run_flag)
-    subprocess.run(["python", "1_gbqr.py",
-                    "--reference_date", str(reference_date)] + short_run_flag)
-    subprocess.run(["Rscript", "2_flusion_ensemble.R", str(reference_date)])
-    subprocess.run(["Rscript", "3_plot.R", str(reference_date)])
+
+    for script_args in [["python", "0_ar6_pooled.py", "--reference_date", str(reference_date)] + short_run_flag,
+                        ["python", "1_gbqr.py", "--reference_date", str(reference_date)] + short_run_flag,
+                        ["Rscript", "2_flusion_ensemble.R", str(reference_date)],
+                        ["Rscript", "3_plot.R", str(reference_date)]]:
+        run_script(script_args)
 
 
 if __name__ == "__main__":

--- a/util/utils.py
+++ b/util/utils.py
@@ -1,0 +1,14 @@
+import subprocess
+import sys
+
+
+def run_script(process_args):
+    """
+    Simple util that calls `subprocess.run()` on `process_args`, exiting with status 1 if the process did not return 0.
+
+    :param process_args: list of `subprocess.run()` args
+    """
+    completed_process = subprocess.run(process_args)
+    if completed_process.returncode != 0:
+        print(f"error calling script: {process_args}")
+        sys.exit(1)  # 0: Success, 1: General Error


### PR DESCRIPTION
This PR implements #22 by 1) changing `main.py` files to call a new `run_script()` util, which catches script errors and exits if so, and 2) changes all `*_plot.R` files to wrap`try()` around `readr::read_csv()` calls and `stop()` with a helpful message if the read failed.

Notes: We should probably refactor the `*_plot.R` files to use a utility function like the Python `run_script()` one, but I wasn't sure the best way to do this (I'm still not super confident on R coding). I'm thinking:
```R
try_read_csv <- function(raw_target_url) { ... }
```

That function would include the url as part of the `stop()` message.

Would it be legit to simply add `utils.R` to the `utils/` dir that `utils.py` is in? How would the import look? Sorry - it's been a while on the R side...