### PR TITLE
removes the REPO_NAME environment variable, replacing it with the hard-coded "hub-repo" name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Environment variables: There are two sources of environment variables used by th
     - `DRY_RUN` (optional): when set (to anything), stops git commit actions from happening (default is to do commits).
 2. This repo's [run.sh](run.sh) is parameterized to work with this repo's different models, so running the [Dockerfile](Dockerfile) for a particular model uses the following environment variables. These can be passed via [docker run](https://docs.docker.com/reference/cli/docker/container/run/)'s `--env` or `--env-file` args.
     - `MODEL_NAME` (required): Hub name of the model (i.e., the name used in model outputs). Example: `MODEL_NAME=UMass-AR2`
-    - `REPO_NAME` (required): Name of the repository being cloned. Example: `REPO_NAME=FluSight-forecast-hub`
     - `REPO_URL` (required): Full URL of the repository being cloned, excluding ".git". Example: `REPO_URL=https://github.com/reichlab/FluSight-forecast-hub`
     - `REPO_UPSTREAM_URL` (required): Full URL of the repository that `REPO_URL` was forked from, excluding ".git". Example: `REPO_UPSTREAM_URL=https://github.com/cdcepi/FluSight-forecast-hub`
     - `MAIN_PY_ARGS` (optional): Specifies arguments that are passed through to [run.sh](run.sh)'s call to the particular model's `main.py`. Note that these arguments are model-specific. For example, the
@@ -47,7 +46,6 @@ Example run command:
 docker run --rm \
   --env-file path_to_env_file/git-and-slack-credentials.env \
   --env MODEL_NAME="UMass-AR2" \
-  --env REPO_NAME="FluSight-forecast-hub" \
   ... \
   --env DRY_RUN=1 \
   flu_ar2:1.0

--- a/run.sh
+++ b/run.sh
@@ -23,8 +23,8 @@ source "${APP_DIR}/container-utils/scripts/slack.sh"
 # check for additional required environment variables
 #
 
-if [ -z ${MODEL_NAME+x} ] || [ -z ${REPO_NAME+x} ] || [ -z ${REPO_URL+x} ] || [ -z ${REPO_UPSTREAM_URL+x} ]; then
-  slack_message "one or more additional required environment variables were unset: MODEL_NAME='${MODEL_NAME}', REPO_NAME='${REPO_NAME}', REPO_URL='${REPO_URL}', REPO_UPSTREAM_URL='${REPO_UPSTREAM_URL}'"
+if [ -z ${MODEL_NAME+x} ] || [ -z ${REPO_URL+x} ] || [ -z ${REPO_UPSTREAM_URL+x} ]; then
+  slack_message "one or more additional required environment variables were unset: MODEL_NAME='${MODEL_NAME}', REPO_URL='${REPO_URL}', REPO_UPSTREAM_URL='${REPO_UPSTREAM_URL}'"
   exit 1 # fail
 else
   slack_message "found all additional required environment variables"
@@ -34,7 +34,7 @@ fi
 # start
 #
 
-slack_message "${MODEL_NAME}: entered. id=$(id -u -n), HOME=${HOME}, PWD=${PWD}, DRY_RUN='${DRY_RUN+x}', GIT_USER_NAME=${GIT_USER_NAME}, MODEL_NAME=${MODEL_NAME}, REPO_NAME=${REPO_NAME}, REPO_URL=${REPO_URL}, REPO_UPSTREAM_URL=${REPO_UPSTREAM_URL}"
+slack_message "${MODEL_NAME}: entered. id=$(id -u -n), HOME=${HOME}, PWD=${PWD}, DRY_RUN='${DRY_RUN+x}', GIT_USER_NAME=${GIT_USER_NAME}, MODEL_NAME=${MODEL_NAME}, REPO_URL=${REPO_URL}, REPO_UPSTREAM_URL=${REPO_UPSTREAM_URL}"
 
 #
 # build the model
@@ -92,7 +92,7 @@ fi
 # the extension, e.g., '2024-01-06-UMass-AR2'
 
 # clone the repo
-HUB_DIR="${APP_DIR}/${REPO_NAME}"
+HUB_DIR="${APP_DIR}/hub-repo"  # hard-coded repo name
 slack_message "${MODEL_NAME}: cloning ${REPO_URL} -> ${HUB_DIR}"
 git clone "${REPO_URL}" "${HUB_DIR}"
 cd ${HUB_DIR}


### PR DESCRIPTION
Implements #26 (cleans up by removing an unnecessary environment variable - one less thing for modelers to worry about)