### PR TITLE
Update covid model plotting code

### DIFF
--- a/covid_ar6_pooled/1_plot.R
+++ b/covid_ar6_pooled/1_plot.R
@@ -14,8 +14,7 @@ args <- commandArgs(trailingOnly = TRUE)
 ref_date <- as.Date(args[1])
 data_date <- ref_date - 3
 
-locations <- read.csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
-
+locations <- read.csv("https://raw.githubusercontent.com/CDCgov/covid19-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
 
 hub_con <- hubData::connect_model_output("output/model-output")
 forecasts <- hub_con |>

--- a/covid_gbqr/1_plot.R
+++ b/covid_gbqr/1_plot.R
@@ -14,7 +14,7 @@ args <- commandArgs(trailingOnly = TRUE)
 ref_date <- as.Date(args[1])
 data_date <- ref_date - 3
 
-locations <- read.csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
+locations <- read.csv("https://raw.githubusercontent.com/CDCgov/covid19-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
 
 selected_model <- "UMass-gbqr"
 


### PR DESCRIPTION
The covid models had previously gotten some location meta data from FluSight, which was joined with the forecast data. This PR changes the source of this location metadata to [that from the covid hub](https://github.com/reichlab/cdcgov-covid19-forecast-hub/blob/main/auxiliary-data/locations.csv).

This change also fixes a bug in which our most recent runs of these models failed to plot forecasts for locations with fips codes that that contained a leading zero. The bug originated from [the FluSight location auxiliary data being updated and its location column no longer containing a leading zero in the fips codes](https://github.com/cdcepi/FluSight-forecast-hub/blob/8327d8bfae33419924c2cae7ab196e5e381a199e/auxiliary-data/locations.csv). The covid hub data does not contain this issue of missing within zeros. We will update the flu model plotting code in another PR

I ran the new plotting code locally and everything worked as expected