### PR TITLE
updated .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,7 @@
-.venv
-covid_ar6_pooled/.venv
+.venv/
 __pycache__/
 *.pyc
+**/output/
+.git/
+.idea/
+**/.DS_Store


### PR DESCRIPTION
Read about the .dockerignore [here](https://docs.docker.com/build/concepts/context/#dockerignore-files). I tested this manually using [this post](https://stackoverflow.com/a/40966234):

```bash
cd /.../operational-models

docker image build --no-cache -t build-context -f - . <<EOF
FROM busybox
WORKDIR /build-context
COPY . .
CMD find .
EOF

# run the default find command, and then visually ensure desired files are actually excluded
docker container run --rm build-context

docker image rm build-context
```

Chat analysis:
    Here's what each line in that .dockerignore file does:

    .venv/

    Ignores the .venv directory at the root (typically a Python virtual environment folder).

    __pycache__/

    Ignores any directory named __pycache__ at the root level (Python's bytecode cache directory).

    *.pyc

    Ignores all files with the .pyc extension anywhere in the build context (compiled Python bytecode files).

    **/output/

    Ignores any directory named output located anywhere in the root or any subdirectory (all contents inside those output folders are ignored).

    .git/

    Ignores the .git folder at the root (Git repository metadata, not needed inside Docker images).

    .idea/

    Ignores the .idea directory at the root (configuration files created by JetBrains IDEs like PyCharm).

    **/.DS_Store

    Ignores any .DS_Store files anywhere in the directory tree (macOS hidden metadata files).
