### PR TITLE
Update plotting scripts to extend plotted full season target data

### DIFF
--- a/covid_ar6_pooled/1_plot.R
+++ b/covid_ar6_pooled/1_plot.R
@@ -83,7 +83,7 @@ p <- plot_step_ahead_model_output(
 )
 
 data_2022_23 <- target_data |>
-  dplyr::filter(date >= "2022-09-01", date <= "2023-06-01", !is.na(location))
+  dplyr::filter(date >= "2022-09-01", date <= "2023-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2022_23 |> dplyr::mutate(date = date + 3 * 365),
@@ -91,7 +91,7 @@ p <- p +
   )
 
 data_2023_24 <- target_data |>
-  dplyr::filter(date >= "2023-09-01", date <= "2024-06-01", !is.na(location))
+  dplyr::filter(date >= "2023-09-01", date <= "2024-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2023_24 |> dplyr::mutate(date = date + 2 * 365),
@@ -100,7 +100,7 @@ p <- p +
 
 
 data_2024_25 <- target_data |>
-  dplyr::filter(date >= "2024-09-01", date <= "2025-06-01", !is.na(location))
+  dplyr::filter(date >= "2024-09-01", date <= "2025-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2024_25 |> dplyr::mutate(date = date + 365),

--- a/covid_gbqr/1_plot.R
+++ b/covid_gbqr/1_plot.R
@@ -82,7 +82,7 @@ p <- plot_step_ahead_model_output(
 )
 
 data_2022_23 <- target_data |>
-  dplyr::filter(date >= "2022-09-01", date <= "2023-06-01", !is.na(location))
+  dplyr::filter(date >= "2022-09-01", date <= "2023-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2022_23 |> dplyr::mutate(date = date + 3 * 365),
@@ -90,7 +90,7 @@ p <- p +
   )
 
 data_2023_24 <- target_data |>
-  dplyr::filter(date >= "2023-09-01", date <= "2024-06-01", !is.na(location))
+  dplyr::filter(date >= "2023-09-01", date <= "2024-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2023_24 |> dplyr::mutate(date = date + 2 * 365),
@@ -98,7 +98,7 @@ p <- p +
   )
 
 data_2024_25 <- target_data |>
-  dplyr::filter(date >= "2024-09-01", date <= "2025-06-01", !is.na(location))
+  dplyr::filter(date >= "2024-09-01", date <= "2025-08-31", !is.na(location))
 p <- p +
   ggplot2::geom_line(
     data = data_2024_25 |> dplyr::mutate(date = date + 365),

--- a/covid_gbqr/1_plot.R
+++ b/covid_gbqr/1_plot.R
@@ -24,7 +24,6 @@ forecasts <- hub_con |>
   dplyr::collect() |>
   dplyr::left_join(locations)
 
-# target_data <- readr::read_csv("https://raw.githubusercontent.com/CDCgov/covid19-forecast-hub/refs/heads/main/target-data/covid-hospital-admissions.csv") |>
 target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
   dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total COVID-19 Admissions"))
 colnames(target_data) <- c("date", "abbreviation", "value")

--- a/flu_ar2/plot.R
+++ b/flu_ar2/plot.R
@@ -80,7 +80,7 @@ p <- plot_step_ahead_model_output(
 )
 
 data_2022_23 <- target_data |>
-  dplyr::filter(date >= "2022-09-01", date <= "2023-06-01")
+  dplyr::filter(date >= "2022-09-01", date <= "2023-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2022_23 |> dplyr::mutate(date = date + 3 * 365),
@@ -88,7 +88,7 @@ p <- p +
   )
 
 data_2023_24 <- target_data |>
-  dplyr::filter(date >= "2023-09-01", date <= "2024-06-01")
+  dplyr::filter(date >= "2023-09-01", date <= "2024-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2023_24 |> dplyr::mutate(date = date + 2 * 365),
@@ -96,7 +96,7 @@ p <- p +
   )
 
 data_2024_25 <- target_data |>
-  dplyr::filter(date >= "2024-09-01", date <= "2025-06-01")
+  dplyr::filter(date >= "2024-09-01", date <= "2025-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2024_25 |> dplyr::mutate(date = date + 365),

--- a/flu_flusion/3_plot.R
+++ b/flu_flusion/3_plot.R
@@ -88,7 +88,7 @@ p <- plot_step_ahead_model_output(
 )
 
 data_2022_23 <- target_data |>
-  dplyr::filter(date >= "2022-09-01", date <= "2023-06-01")
+  dplyr::filter(date >= "2022-09-01", date <= "2023-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2022_23 |> dplyr::mutate(date = date + 3 * 365),
@@ -96,7 +96,7 @@ p <- p +
   )
 
 data_2023_24 <- target_data |>
-  dplyr::filter(date >= "2023-09-01", date <= "2024-06-01")
+  dplyr::filter(date >= "2023-09-01", date <= "2024-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2023_24 |> dplyr::mutate(date = date + 2 * 365),
@@ -104,7 +104,7 @@ p <- p +
   )
 
 data_2024_25 <- target_data |>
-  dplyr::filter(date >= "2024-09-01", date <= "2025-06-01")
+  dplyr::filter(date >= "2024-09-01", date <= "2025-06-15")
 p <- p +
   ggplot2::geom_line(
     data = data_2024_25 |> dplyr::mutate(date = date + 365),


### PR DESCRIPTION
Our plotting scripts that plot the past full seasons of target data for comparison with the current season's forecasts only included target data from 09/01 to 06/01, which leaves out 3 months of data during which COVID-19 forecasts are made (and some flu forecasting seasons have extended into June as well). This PR extends the plotted target data for COVID-19 to 08/31 and for flu to 06/15.