### PR TITLE
Use versioned target data for pmf forecasts

### DIFF
--- a/flu_flusion/2_flusion_ensemble.R
+++ b/flu_flusion/2_flusion_ensemble.R
@@ -5,6 +5,7 @@ library(hubEnsembles)
 
 args <- commandArgs(trailingOnly = TRUE)
 ref_date <- as.Date(args[1])
+data_date <- ref_date - 3
 
 hub_con <- hubData::connect_model_output("intermediate-output/model-output")
 
@@ -13,11 +14,25 @@ model_out_tbl <- dplyr::collect(hub_con) |>
   dplyr::filter(reference_date == ref_date, horizon >= 0) |>
   hubEnsembles::simple_ensemble(model_id = "UMass-flusion")
 
-# add categorical target predictions
-target_ts <- readr::read_csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/main/target-data/target-hospital-admissions.csv")
+# load location metadata and target data
 location_meta <- readr::read_csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
+target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+  dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total Influenza Admissions"))
+colnames(target_data) <- c("date", "abbreviation", "value")
+target_data <- target_data |>
+  dplyr::mutate(
+    abbreviation = ifelse(abbreviation == "USA", "US", abbreviation)
+  ) |>
+  dplyr::left_join(location_meta) |>
+  dplyr::filter(!is.na(location_name))
+target_ts <- target_data |>
+  dplyr::select("date", "location", "value") |>
+  dplyr::arrange(dplyr::desc(date)) |>
+  dplyr::rename(time_index = date, observation = value)
+
+# add categorical target predictions
 bin_endpoints <- idforecastutils::get_flusight_bin_endpoints(
-  target_ts = target_ts,
+  target_ts = target_data,
   location_meta = location_meta,
   season = "2024/25"
 )

--- a/flu_trends_ensemble/main.R
+++ b/flu_trends_ensemble/main.R
@@ -10,12 +10,21 @@ args <- commandArgs(trailingOnly = TRUE)
 
 reference_date <- as.Date(args[1])
 reference_date <- lubridate::ymd(reference_date)
+data_date <- reference_date - 3
 
 locations <- read.csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/refs/heads/main/auxiliary-data/locations.csv")
 required_quantiles <- c(0.01, 0.025, seq(0.05, 0.95, by = 0.05), 0.975, 0.99)
 
 # load target data
-target_data <- readr::read_csv("https://raw.githubusercontent.com/cdcepi/FluSight-forecast-hub/main/target-data/target-hospital-admissions.csv")
+target_data <- readr::read_csv(paste0("https://infectious-disease-data.s3.amazonaws.com/data-raw/influenza-nhsn/nhsn-", data_date, ".csv")) |>
+  dplyr::select(c("Week Ending Date", "Geographic aggregation", "Total Influenza Admissions"))
+colnames(target_data) <- c("date", "location", "value")
+target_data <- target_data |>
+  dplyr::mutate(
+    abbreviation = ifelse(abbreviation == "USA", "US", abbreviation)
+  ) |>
+  dplyr::left_join(locations) |>
+  dplyr::filter(!is.na(location_name))
 target_ts <- target_data |>
   dplyr::select("date", "location", "value") |>
   dplyr::arrange(dplyr::desc(date)) |>


### PR DESCRIPTION
Motivated by letting us fully reproduce a run for a past reference date, using the data available at that time for transforming the quantile forecasts into PMF ones.