### PR TITLE
fixes "failed to resolve remote" warning messages during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,9 @@ ENV RENV_PATHS_LIBRARY="renv/library"
 # Posit Public Package Manager setup: https://p3m.dev/client/#/repos/cran/setup
 RUN /rocker_scripts/setup_R.sh https://p3m.dev/cran/__linux__/jammy/2025-02-05
 RUN Rscript -e "install.packages('renv')"
-RUN Rscript -e "renv::restore()"
+RUN --mount=type=secret,id=github_pat \
+    GITHUB_PAT="$(cat /run/secrets/github_pat)" \
+    Rscript -e "renv::restore()"
 
 # clone https://github.com/reichlab/container-utils. ADD is a hack ala https://stackoverflow.com/questions/35134713/disable-cache-for-specific-run-commands
 ADD "https://api.github.com/repos/reichlab/container-utils/commits?per_page=1" latest_commit

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -82,7 +82,9 @@ ENV RENV_PATHS_LIBRARY="renv/library"
 # Posit Public Package Manager setup: https://p3m.dev/client/#/repos/cran/setup
 RUN /rocker_scripts/setup_R.sh https://p3m.dev/cran/__linux__/jammy/2025-02-05
 RUN Rscript -e "install.packages('renv')"
-RUN Rscript -e "renv::restore()"
+RUN --mount=type=secret,id=github_pat \
+    GITHUB_PAT="$(cat /run/secrets/github_pat)" \
+    Rscript -e "renv::restore()"
 
 # clone https://github.com/reichlab/container-utils. ADD is a hack ala https://stackoverflow.com/questions/35134713/disable-cache-for-specific-run-commands
 ADD "https://api.github.com/repos/reichlab/container-utils/commits?per_page=1" latest_commit

--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ Environment variables: Building the [Dockerfile](Dockerfile) for a particular mo
 
 - (required) `MODEL_DIR`: specifies the directory name (not full path) of the model being built. Example: `MODEL_DIR=flu_ar2`.
 
+The build also requires a GitHub Personal Access Token, passed as a [BuildKit build secret](https://docs.docker.com/build/building/secrets/) with id `github_pat`. This is used by the `renv::restore()` step, which resolves GitHub-hosted R packages (e.g. `hubverse-org/hubUtils`, `hubverse-org/hubVis`) via the GitHub API. Without an authenticated token, the many GitHub API calls made during resolution can exceed GitHub's unauthenticated rate limit, causing `renv::restore()` to fail intermittently. Provide the token via an environment variable (e.g. `read -rsp "GitHub PAT: " GITHUB_PAT && echo && export GITHUB_PAT`), which is passed to `docker build` with `--secret id=github_pat,env=GITHUB_PAT`.
+
 Example build command:
 
 ```bash
 cd "path-to-this-repo"
-docker build --build-arg MODEL_DIR=flu_ar2 --tag=flu_ar2:1.0 --file=Dockerfile .
+# set GITHUB_PAT as documented above
+docker build \
+  --secret id=github_pat,env=GITHUB_PAT \
+  --build-arg MODEL_DIR=flu_ar2 --tag=flu_ar2:1.0 --file=Dockerfile .
 ```
 
 ## To run the image locally
@@ -58,10 +63,15 @@ Use the following commands to build and push an image. These use the `flu_ar2` m
 > Note: We build for the `amd64` architecture because that's what most Linux-based servers (including AWS) use natively. This is as opposed to Apple Silicon Macs, which have an `arm64` architecture.
 > Note: For Macs with Apple silicon chips as of this writing, specifying `--platform=linux/amd64` causes the build to fail unless you disable Rosetta in Docker Desktop. For details, see [Buildx throws Illegal Instruction installing ca-certificates when building for linux/amd64 on M2 #7255](https://github.com/docker/for-mac/issues/7255).
 
+The `docker build` step here is identical to [To build the image](#to-build-the-image) and requires the same `--secret id=github_pat,env=GITHUB_PAT` (with `GITHUB_PAT` exported). The `docker push` step does not use the token.
+
 ```bash
 cd "path-to-this-repo"
+# set GITHUB_PAT as documented above
 docker login -u "reichlab" docker.io
-docker build --platform=linux/amd64 --build-arg MODEL_DIR=flu_ar2 --tag=reichlab/flu_ar2:1.0 --file=Dockerfile .
+docker build --platform=linux/amd64 \
+  --secret id=github_pat,env=GITHUB_PAT \
+  --build-arg MODEL_DIR=flu_ar2 --tag=reichlab/flu_ar2:1.0 --file=Dockerfile .
 docker push reichlab/flu_ar2:1.0
 ```
 
@@ -144,6 +154,7 @@ A `renv.lock` file is generated via the following steps. As noted above, the "in
    Rscript -e "renv::install('hubverse-org/hubData@*release')"
    Rscript -e "renv::install('hubverse-org/hubVis@*release')"
    ```
+   > Note: The hubverse R packages (`hubUtils`, `hubVis`, `hubEnsembles`, `hubExamples`) were renamed from the `Infectious-Disease-Modeling-Hubs` GitHub org to `hubverse-org`. The old org path still works via a GitHub redirect (HTTP 301), but each redirect adds an extra GitHub API call per package on every build. The `renv.lock` files reference the canonical `hubverse-org` paths to avoid these redirects and reduce API traffic (which, together with the authenticated build PAT, helps avoid GitHub API rate-limit failures during `renv::restore()`). Reference these packages under `hubverse-org/...` when regenerating a lockfile.
 7. create `renv.lock` from within the R interpreter (this fails in bash) via:
    ```R
    renv::settings$snapshot.type('all') ; renv::snapshot()

--- a/covid_ar6_pooled/renv.lock
+++ b/covid_ar6_pooled/renv.lock
@@ -2122,7 +2122,7 @@
       "Maintainer": "Anna Krystalli <annakrystalli@googlemail.com>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubUtils",
       "RemoteRef": "main",
       "RemoteSha": "01b24216854a34df2455bfd5b8164d49fd21a675"
@@ -2215,7 +2215,7 @@
       "RemoteRepo": "idforecastutils",
       "RemoteRef": "main",
       "RemoteSha": "0caa1626d98276aaf148641b12394ba6f6b5fa27",
-      "Remotes": "Infectious-Disease-Modeling-Hubs/hubEnsembles, Infectious-Disease-Modeling-Hubs/hubExamples, Infectious-Disease-Modeling-Hubs/hubUtils, Infectious-Disease-Modeling-Hubs/hubVis, reichlab/distfromq, reichlab/covidData"
+      "Remotes": "hubverse-org/hubEnsembles, hubverse-org/hubExamples, hubverse-org/hubUtils, hubverse-org/hubVis, reichlab/distfromq, reichlab/covidData"
     },
     "ini": {
       "Package": "ini",

--- a/covid_gbqr/renv.lock
+++ b/covid_gbqr/renv.lock
@@ -2070,7 +2070,7 @@
       "Maintainer": "Anna Krystalli <annakrystalli@googlemail.com>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubUtils",
       "RemoteRef": "main",
       "RemoteSha": "01b24216854a34df2455bfd5b8164d49fd21a675"
@@ -2114,7 +2114,7 @@
       "Maintainer": "Lucie Contamin <contamin@pitt.edu>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubVis",
       "RemoteRef": "main",
       "RemoteSha": "5d1ca745b67f0e6ebaa1a2ed91b41bf3b3f4f57b",
@@ -2163,7 +2163,7 @@
       "RemoteRepo": "idforecastutils",
       "RemoteRef": "main",
       "RemoteSha": "0caa1626d98276aaf148641b12394ba6f6b5fa27",
-      "Remotes": "Infectious-Disease-Modeling-Hubs/hubEnsembles, Infectious-Disease-Modeling-Hubs/hubExamples, Infectious-Disease-Modeling-Hubs/hubUtils, Infectious-Disease-Modeling-Hubs/hubVis, reichlab/distfromq, reichlab/covidData"
+      "Remotes": "hubverse-org/hubEnsembles, hubverse-org/hubExamples, hubverse-org/hubUtils, hubverse-org/hubVis, reichlab/distfromq, reichlab/covidData"
     },
     "ini": {
       "Package": "ini",

--- a/flu_flusion/renv.lock
+++ b/flu_flusion/renv.lock
@@ -2122,7 +2122,7 @@
       "Maintainer": "Anna Krystalli <annakrystalli@googlemail.com>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubUtils",
       "RemoteRef": "main",
       "RemoteSha": "fa181282373e17ff30bce16e8e29844b8dd1110f"
@@ -2166,7 +2166,7 @@
       "Maintainer": "Lucie Contamin <contamin@pitt.edu>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubVis",
       "RemoteRef": "main",
       "RemoteSha": "a2446846533953b8afb3255152a0218fbae16658",
@@ -2215,7 +2215,7 @@
       "RemoteRepo": "idforecastutils",
       "RemoteRef": "main",
       "RemoteSha": "0caa1626d98276aaf148641b12394ba6f6b5fa27",
-      "Remotes": "Infectious-Disease-Modeling-Hubs/hubEnsembles, Infectious-Disease-Modeling-Hubs/hubExamples, Infectious-Disease-Modeling-Hubs/hubUtils, Infectious-Disease-Modeling-Hubs/hubVis, reichlab/distfromq, reichlab/covidData"
+      "Remotes": "hubverse-org/hubEnsembles, hubverse-org/hubExamples, hubverse-org/hubUtils, hubverse-org/hubVis, reichlab/distfromq, reichlab/covidData"
     },
     "ini": {
       "Package": "ini",

--- a/flu_trends_ensemble/renv.lock
+++ b/flu_trends_ensemble/renv.lock
@@ -2923,7 +2923,7 @@
       "Maintainer": "Anna Krystalli <annakrystalli@googlemail.com>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubUtils",
       "RemoteRef": "main",
       "RemoteSha": "97b50ab0b62ad9da8775896912ce34ddf144893f"
@@ -2967,7 +2967,7 @@
       "Maintainer": "Lucie Contamin <contamin@pitt.edu>",
       "RemoteType": "github",
       "RemoteHost": "api.github.com",
-      "RemoteUsername": "Infectious-Disease-Modeling-Hubs",
+      "RemoteUsername": "hubverse-org",
       "RemoteRepo": "hubVis",
       "RemoteRef": "main",
       "RemoteSha": "a2446846533953b8afb3255152a0218fbae16658",
@@ -3016,7 +3016,7 @@
       "RemoteRepo": "idforecastutils",
       "RemoteRef": "main",
       "RemoteSha": "0caa1626d98276aaf148641b12394ba6f6b5fa27",
-      "Remotes": "Infectious-Disease-Modeling-Hubs/hubEnsembles, Infectious-Disease-Modeling-Hubs/hubExamples, Infectious-Disease-Modeling-Hubs/hubUtils, Infectious-Disease-Modeling-Hubs/hubVis, reichlab/distfromq, reichlab/covidData"
+      "Remotes": "hubverse-org/hubEnsembles, hubverse-org/hubExamples, hubverse-org/hubUtils, hubverse-org/hubVis, reichlab/distfromq, reichlab/covidData"
     },
     "ini": {
       "Package": "ini",


### PR DESCRIPTION
Implements [[building Docker images results in "failed to resolve remote" warning messages #51]](https://github.com/reichlab/operational-models/issues/51) by authenticating `renv::restore()` and dropping redirect hops to fix GitHub API rate-limiting.

Overview: `renv::restore()` resolves GitHub-hosted R packages via the GitHub API during the Docker build. Unauthenticated, these calls hit GitHub's low anonymous rate limit and fail intermittently with "failed to resolve remote." Two changes reduce and authenticate that API traffic:

- Dockerfile / Dockerfile.dev: pass a GitHub PAT to renv::restore() as a BuildKit secret (--mount=type=secret,id=github_pat), raising the rate-limit ceiling from anonymous (~60/hr) to authenticated (~5000/hr).
- renv.lock (covid_ar6_pooled, covid_gbqr, flu_flusion, flu_trends_ensemble): update hubUtils, hubVis, and the idforecastutils Remotes list from the old Infectious-Disease-Modeling-Hubs org to the renamed hubverse-org org. The old paths still work via GitHub 301 redirects, but each redirect costs an extra API call per package on every build.

This PR also documents the required build PAT and the org rename in README.md.